### PR TITLE
added UAlertControllerExtensions to BaseViewController

### DIFF
--- a/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate.xcodeproj/project.pbxproj
+++ b/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C612A1F61E9F197100A7A4BE /* CodeDoesGood_iOSTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C612A1F51E9F197100A7A4BE /* CodeDoesGood_iOSTemplateTests.swift */; };
 		C612A2011E9F197100A7A4BE /* CodeDoesGood_iOSTemplateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C612A2001E9F197100A7A4BE /* CodeDoesGood_iOSTemplateUITests.swift */; };
 		C612A20F1E9F19B000A7A4BE /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C612A20E1E9F19B000A7A4BE /* BaseViewController.swift */; };
+		C676B65F1EB18BD1009386E7 /* CodeDoesGoodiOS+UIAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C676B65E1EB18BD1009386E7 /* CodeDoesGoodiOS+UIAlert.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		C612A2001E9F197100A7A4BE /* CodeDoesGood_iOSTemplateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeDoesGood_iOSTemplateUITests.swift; sourceTree = "<group>"; };
 		C612A2021E9F197100A7A4BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C612A20E1E9F19B000A7A4BE /* BaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		C676B65E1EB18BD1009386E7 /* CodeDoesGoodiOS+UIAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CodeDoesGoodiOS+UIAlert.swift"; sourceTree = "<group>"; };
 		C6FF85D5185F260B0F79A904 /* Pods-CodeDoesGood-iOSTemplateTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CodeDoesGood-iOSTemplateTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CodeDoesGood-iOSTemplateTests/Pods-CodeDoesGood-iOSTemplateTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FB87D7317A86FE822D7A4088 /* Pods-CodeDoesGood-iOSTemplateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CodeDoesGood-iOSTemplateTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CodeDoesGood-iOSTemplateTests/Pods-CodeDoesGood-iOSTemplateTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -133,6 +135,7 @@
 				C612A1E71E9F197100A7A4BE /* Assets.xcassets */,
 				C612A1E91E9F197100A7A4BE /* LaunchScreen.storyboard */,
 				C612A1EC1E9F197100A7A4BE /* Info.plist */,
+				C676B65E1EB18BD1009386E7 /* CodeDoesGoodiOS+UIAlert.swift */,
 			);
 			path = "CodeDoesGood-iOSTemplate";
 			sourceTree = "<group>";
@@ -322,7 +325,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		53BD0AF13BE1B80FFF21690A /* [CP] Embed Pods Frameworks */ = {
@@ -367,7 +370,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		6501E5D7AC0F4059C8A30CD7 /* [CP] Copy Pods Resources */ = {
@@ -412,7 +415,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F8AFFD840CA54FDDE3664770 /* [CP] Copy Pods Resources */ = {
@@ -455,6 +458,7 @@
 				C612A1E31E9F197100A7A4BE /* ViewController.swift in Sources */,
 				C612A1E11E9F197100A7A4BE /* AppDelegate.swift in Sources */,
 				C612A20F1E9F19B000A7A4BE /* BaseViewController.swift in Sources */,
+				C676B65F1EB18BD1009386E7 /* CodeDoesGoodiOS+UIAlert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -713,6 +717,7 @@
 				C612A2071E9F197100A7A4BE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C612A2081E9F197100A7A4BE /* Build configuration list for PBXNativeTarget "CodeDoesGood-iOSTemplateTests" */ = {
 			isa = XCConfigurationList;
@@ -721,6 +726,7 @@
 				C612A20A1E9F197100A7A4BE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C612A20B1E9F197100A7A4BE /* Build configuration list for PBXNativeTarget "CodeDoesGood-iOSTemplateUITests" */ = {
 			isa = XCConfigurationList;
@@ -729,6 +735,7 @@
 				C612A20D1E9F197100A7A4BE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/BaseViewController.swift
+++ b/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/BaseViewController.swift
@@ -26,3 +26,24 @@ class BaseViewController: UIViewController {
         view.endEditing(true)
     }
 }
+
+
+extension UIAlertController {
+    func featureNotImplementedAlert() {
+        let alert = UIAlertController(title: "This feature is not yet implemented", message: nil, preferredStyle: .alert)
+        let okayAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        alert.addAction(okayAction)
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+    func customUIAlert(title : String, message : String, buttonName: String?, action : @escaping ((UIAlertAction) -> Void?)) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        alert.addAction(cancelAction)
+        
+        guard let buttonName = buttonName else { return }
+        
+        let customButtonAction = UIAlertAction(title: buttonName, style: .default, handler: action as? (UIAlertAction) -> Void)
+        alert.addAction(customButtonAction)
+    }
+}

--- a/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/BaseViewController.swift
+++ b/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/BaseViewController.swift
@@ -28,22 +28,3 @@ class BaseViewController: UIViewController {
 }
 
 
-extension UIAlertController {
-    func featureNotImplementedAlert() {
-        let alert = UIAlertController(title: "This feature is not yet implemented", message: nil, preferredStyle: .alert)
-        let okayAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
-        alert.addAction(okayAction)
-        self.present(alert, animated: true, completion: nil)
-    }
-    
-    func customUIAlert(title : String, message : String, buttonName: String?, action : @escaping ((UIAlertAction) -> Void?)) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-        alert.addAction(cancelAction)
-        
-        guard let buttonName = buttonName else { return }
-        
-        let customButtonAction = UIAlertAction(title: buttonName, style: .default, handler: action as? (UIAlertAction) -> Void)
-        alert.addAction(customButtonAction)
-    }
-}

--- a/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/CodeDoesGoodiOS+UIAlert.swift
+++ b/iOS-Template/CodeDoesGood-iOSTemplate/CodeDoesGood-iOSTemplate/CodeDoesGoodiOS+UIAlert.swift
@@ -1,0 +1,30 @@
+//
+//  CodeDoesGoodiOS+UIAlert.swift
+//  CodeDoesGood-iOSTemplate
+//
+//  Created by Christopher Myers on 4/26/17.
+//  Copyright © 2017 Code Does Good. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIAlertController {
+    func featureNotImplementedAlert() {
+        let alert = UIAlertController(title: "This feature is not yet implemented", message: nil, preferredStyle: .alert)
+        let okayAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        alert.addAction(okayAction)
+        self.present(alert, animated: true, completion: nil)
+    }
+    
+    func customUIAlert(title : String, message : String, buttonName: String?, action : @escaping ((UIAlertAction) -> Void?)) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        alert.addAction(cancelAction)
+        
+        guard let buttonName = buttonName else { return }
+        
+        let customButtonAction = UIAlertAction(title: buttonName, style: .default, handler: action as? (UIAlertAction) -> Void)
+        alert.addAction(customButtonAction)
+    }
+}


### PR DESCRIPTION
added two UIAlertControllerExtensions to BaseViewController.  One is a default action with zero customization to alert the user that a feature is not implemented.  This alert will present itself by default.

The other is a customizable alert that sets ups a customizable button and completion handler, but does not add text boxes to the alert controller.  This alert does not self present, but will need to have the alert presented by the programmer in whatever VC they're in.  

@abbeyjackson I'd like you to double check these two to make sure it's set up how you'd like before I merge the pull request into Master.  